### PR TITLE
ref: Cleanup/prevent dangling throws

### DIFF
--- a/linux/drivers/char/fusion/fusionee.c
+++ b/linux/drivers/char/fusion/fusionee.c
@@ -319,8 +319,6 @@ Fusionee_PutPacket( Fusionee *fusionee,
 
 /******************************************************************************/
 
-static int lookup_fusionee(FusionDev * dev, FusionID id,
-                           Fusionee ** ret_fusionee);
 static int lock_fusionee(FusionDev * dev, FusionID id,
                          Fusionee ** ret_fusionee);
 
@@ -540,7 +538,7 @@ fusionee_get_info(FusionDev * dev, FusionGetFusioneeInfo * get_info)
      int       ret;
      Fusionee *fusionee;
 
-     ret = lookup_fusionee(dev, get_info->fusion_id, &fusionee);
+     ret = fusionee_lookup(dev, get_info->fusion_id, &fusionee);
      if (ret)
           return ret;
 
@@ -569,7 +567,7 @@ fusionee_send_message(FusionDev * dev,
      Fusionee                *fusionee;
      size_t                   size;
 
-     ret = lookup_fusionee(dev, recipient, &fusionee);
+     ret = fusionee_lookup(dev, recipient, &fusionee);
      if (ret)
           return ret;
 
@@ -1078,10 +1076,8 @@ pid_t fusionee_dispatcher_pid(FusionDev * dev, FusionID fusion_id)
      return ret;
 }
 
-/******************************************************************************/
-
-static int
-lookup_fusionee(FusionDev * dev, FusionID id, Fusionee ** ret_fusionee)
+int
+fusionee_lookup(FusionDev * dev, FusionID id, Fusionee ** ret_fusionee)
 {
      Fusionee *fusionee;
 
@@ -1097,12 +1093,14 @@ lookup_fusionee(FusionDev * dev, FusionID id, Fusionee ** ret_fusionee)
      return -EINVAL;
 }
 
+/******************************************************************************/
+
 static int lock_fusionee(FusionDev * dev, FusionID id, Fusionee ** ret_fusionee)
 {
      int ret;
      Fusionee *fusionee;
 
-     ret = lookup_fusionee(dev, id, &fusionee);
+     ret = fusionee_lookup(dev, id, &fusionee);
      if (ret)
           return ret;
 

--- a/linux/drivers/char/fusion/fusionee.h
+++ b/linux/drivers/char/fusion/fusionee.h
@@ -139,5 +139,7 @@ FusionID fusionee_id(const Fusionee * fusionee);
 
 pid_t fusionee_dispatcher_pid(FusionDev * dev, FusionID fusion_id);
 
+int fusionee_lookup(FusionDev * dev, FusionID id, Fusionee ** ret_fusionee);
+
 
 #endif


### PR DESCRIPTION
fusion_ref_throw() stores Throw entries in FusionRef. These entries are
normally removed by matching fusion_ref_catch() calls.

This doesn't happen if the catcher fusionee never calls fusion_ref_catch(),
e.g. it exits unexpectedly.

Similar situation happens if the catcher fusionee exits just before the throw call.

These dangling throws can cause resource leaks (e.g. video memory).

To fix this issue this change will:
- Remove throws when their catcher fusionee are being destroyed.
- Prevent fusion_ref_throw() to add new throws if the catcher fusionee
  does not exist.

Signed-off-by: Tamas Koloti tamas.koloti@youview.com
