### PR TITLE
call: Cleanup interrupted call executions to prevent lock-up in fusion_call_destroy()

### DIFF
--- a/linux/drivers/char/fusion/call.c
+++ b/linux/drivers/char/fusion/call.c
@@ -1065,6 +1065,18 @@ void fusion_call_destroy_all(FusionDev * dev, Fusionee *fusionee)
                fusion_entry_destroy_locked(call->entry.entries,
                                            &call->entry);
           }
+          else
+          {
+               /* Cleanup call executions initiated and not finished by fusionee */
+               FusionCallExecution *execution, *next;
+               direct_list_foreach_safe (execution, next, call->executions) {
+                    if (execution->caller == fusionee) {
+                         /* Remove and free execution */
+                         remove_execution(call, execution);
+                         free_execution(dev, execution);
+                    }
+               }
+          }
 
           l = next;
      }


### PR DESCRIPTION
Interrupted calls can leave behind FusionCallExecution entries if the
caller quits without retrying the call. This can cause
fusion_call_destroy() to wait forever for these entries to disappear.

fusion_call_destroy_all() only removes call executions related to calls
created by the exiting fusionee. This commit extends this function to also
check calls owned by other fusionees and remove executions initiated by
the exiting fusionee.

Signed-off-by: Tamas Koloti tamas.koloti@youview.com
